### PR TITLE
fix: embed paginator timeout errors

### DIFF
--- a/src/utils/EmbedPaginator.ts
+++ b/src/utils/EmbedPaginator.ts
@@ -98,7 +98,8 @@ export class EmbedPaginator {
             });
         });
 
-        collector.on("end", async () => {
+        collector.on("end", async (_collected, reason) => {
+            if (reason.includes("Delete")) return;
             await interaction.editReply({
                 components: [this.buildButtons(true)],
             });


### PR DESCRIPTION
Fixes two bugs:
- #69
- The bot crashes when it loses access to the interaction before the paginator times out
  - e.g. a user runs a command and immediately deletes the bot's response