### PR TITLE
Update cache when less members than intended are detected

### DIFF
--- a/src/commands/role.ts
+++ b/src/commands/role.ts
@@ -50,6 +50,7 @@ const command: SlashCommand = {
         }
 
         //Check for member count mismatch, as Discord.js may slightly drift due to sharding behaviour
+        interaction.guild.fetch() //discord.js dosen't guarantee we have up to date member count after shard reconnects, so we fetch the guild to get the latest member count, this is a non-expensive operation
         if (interaction.guild.members.cache.size < interaction.guild.memberCount ) {
             console.log(`Cache mismatch detected, refreshing member cache..., timestamp ${new Date().toISOString()}`); //TODO: Remove timestamp when we switch to a proper logger framework
             try {

--- a/src/commands/role.ts
+++ b/src/commands/role.ts
@@ -49,6 +49,23 @@ const command: SlashCommand = {
             });
         }
 
+        //Check for member count mismatch, as Discord.js may slightly drift due to sharding behaviour
+        if (interaction.guild.members.cache.size < interaction.guild.memberCount ) {
+            console.log(`Cache mismatch detected, refreshing member cache..., timestamp ${new Date().toISOString()}`); //TODO: Remove timestamp when we switch to a proper logger framework
+            try {
+                await interaction.guild.members.fetch();
+                console.log(
+                    `Updated member cache for guild ${interaction.guild.name} (${interaction.guild.id})`,
+                );
+            } catch (error) {
+                console.error(
+                    `Failed to update member cache for guild ${interaction.guild.id}:`,
+                    error,
+                );
+            }
+        }
+            
+
         function lookup(roleName: string): GuildMember[] {
             const role = interaction.guild!.roles.cache.find(
                 (r) => r.name === roleName,

--- a/src/commands/role.ts
+++ b/src/commands/role.ts
@@ -50,9 +50,13 @@ const command: SlashCommand = {
         }
 
         //Check for member count mismatch, as Discord.js may slightly drift due to sharding behaviour
-        interaction.guild.fetch() //discord.js dosen't guarantee we have up to date member count after shard reconnects, so we fetch the guild to get the latest member count, this is a non-expensive operation
-        if (interaction.guild.members.cache.size < interaction.guild.memberCount ) {
-            console.log(`Cache mismatch detected, refreshing member cache..., timestamp ${new Date().toISOString()}`); //TODO: Remove timestamp when we switch to a proper logger framework
+        await interaction.guild.fetch(); //discord.js dosen't guarantee we have up to date member count after shard reconnects, so we fetch the guild to get the latest member count, this is a non-expensive operation
+        if (
+            interaction.guild.members.cache.size < interaction.guild.memberCount
+        ) {
+            console.log(
+                `Cache mismatch detected, refreshing member cache..., timestamp ${new Date().toISOString()}`,
+            ); //TODO: Remove timestamp when we switch to a proper logger framework
             try {
                 await interaction.guild.members.fetch();
                 console.log(
@@ -65,7 +69,6 @@ const command: SlashCommand = {
                 );
             }
         }
-            
 
         function lookup(roleName: string): GuildMember[] {
             const role = interaction.guild!.roles.cache.find(


### PR DESCRIPTION
Attempts to fix the cache mismatch issue by fetching all guild members on any invocation of the role command when the cache has fewer members than the guild. This should fix the issue, and I have added logging to help us track how often this occurs. After a few days, we should save the logs and inspect to observe the relative time interval at which re-fetch occurs.