### PR TITLE
fix: make role member mentions optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ build/
 
 # __pycache__
 **/__pycache__/
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,3 @@ build/
 
 # __pycache__
 **/__pycache__/
-.env

--- a/src/commands/role.ts
+++ b/src/commands/role.ts
@@ -40,6 +40,12 @@ const command: SlashCommand = {
                         )
                         .setRequired(true)
                         .setAutocomplete(true),
+                )
+                .addBooleanOption((option) =>
+                    option
+                        .setName("mentions")
+                        .setDescription("Display members as mentions")
+                        .setRequired(false),
                 ),
         ),
     async execute(interaction) {
@@ -135,6 +141,9 @@ const command: SlashCommand = {
         }
 
         if (interaction.options.getSubcommand() === "members") {
+            const useMentions =
+                interaction.options.getBoolean("mentions") ?? false;
+
             members.sort((a, b) => a.displayName.localeCompare(b.displayName));
             const membersCount = members.length;
 
@@ -147,10 +156,13 @@ const command: SlashCommand = {
                         bold(`${membersCount} members`) +
                         "\n" +
                         chunk
-                            .map(
-                                (member) =>
-                                    `${userMention(member!.id)} (${member!.user.username})`,
-                            )
+                            .map((member) => {
+                                if (useMentions) {
+                                    return `${userMention(member!.id)} (${member!.user.username})`;
+                                }
+
+                                return `${bold(member!.displayName)} (${member!.user.username})`;
+                            })
                             .join("\n");
 
                     const embed = new EmbedBuilder()


### PR DESCRIPTION
Closes #168

- changed /role members to show names by default rather than mentions
- gives the user the option to select mentions if they want them