### PR TITLE
feat: add cambridge exam credit command

### DIFF
--- a/src/commands/credits.ts
+++ b/src/commands/credits.ts
@@ -83,7 +83,11 @@ const command: SlashCommand = {
     async execute(interaction) {
         const subcommand = interaction.options.getSubcommand();
         const coursesType: AdvancedCreditType =
-            subcommand === "ap" ? "AP" : subcommand === "ib" ? "IB" : "Cambridge";
+            subcommand === "ap"
+                ? "AP"
+                : subcommand === "ib"
+                  ? "IB"
+                  : "Cambridge";
 
         const userSchool = interaction.options.getString("school");
 
@@ -254,7 +258,8 @@ const command: SlashCommand = {
                             new SeparatorBuilder(),
                         );
 
-                        const units = exam.overrideUnits ?? (Number(course.units) || 0);
+                        const units =
+                            exam.overrideUnits ?? (Number(course.units) || 0);
                         genedCreditTotal += units;
 
                         const courseName =

--- a/src/commands/credits.ts
+++ b/src/commands/credits.ts
@@ -62,11 +62,28 @@ const command: SlashCommand = {
                         .setChoices(SCHOOLS.map((s) => ({ name: s, value: s })))
                         .setRequired(true),
                 ),
+        )
+        .addSubcommand((subcommand) =>
+            subcommand
+                .setName("cambridge")
+                .setDescription(
+                    "Calculate units and courses waived through your Cambridge A Levels",
+                )
+                .addStringOption((option) =>
+                    option
+                        .setName("school")
+                        .setDescription(
+                            "Enter College (DC, CIT, SCS, TEP, MCS, CFA)",
+                        )
+                        .setChoices(SCHOOLS.map((s) => ({ name: s, value: s })))
+                        .setRequired(true),
+                ),
         ),
 
     async execute(interaction) {
+        const subcommand = interaction.options.getSubcommand();
         const coursesType: AdvancedCreditType =
-            interaction.options.getSubcommand() === "ap" ? "AP" : "IB";
+            subcommand === "ap" ? "AP" : subcommand === "ib" ? "IB" : "Cambridge";
 
         const userSchool = interaction.options.getString("school");
 
@@ -152,7 +169,7 @@ const command: SlashCommand = {
                 const awarded: { exam: Exam; courses: Course[] }[] = [];
 
                 const processCategory = (
-                    entries: { examName: string; score: number }[],
+                    entries: { examName: string; score: number | string }[],
                 ) => {
                     entries.forEach(({ examName, score }) => {
                         const sameName = exams.filter(

--- a/src/commands/credits.ts
+++ b/src/commands/credits.ts
@@ -254,7 +254,7 @@ const command: SlashCommand = {
                             new SeparatorBuilder(),
                         );
 
-                        const units = Number(course.units) || 0;
+                        const units = exam.overrideUnits ?? Number(course.units) ?? 0;
                         genedCreditTotal += units;
 
                         const courseName =

--- a/src/commands/credits.ts
+++ b/src/commands/credits.ts
@@ -254,7 +254,7 @@ const command: SlashCommand = {
                             new SeparatorBuilder(),
                         );
 
-                        const units = exam.overrideUnits ?? Number(course.units) ?? 0;
+                        const units = exam.overrideUnits ?? (Number(course.units) || 0);
                         genedCreditTotal += units;
 
                         const courseName =

--- a/src/data/advancedCredit/cambridge-credit.json
+++ b/src/data/advancedCredit/cambridge-credit.json
@@ -235,6 +235,7 @@
         "courses": ["36-225"],
         "subject": "STEM",
         "school": [],
+        "overrideUnits": 0,
         "info": "Prerequisite waiver only: if a student takes and passes 36-226, 9 units of credit is awarded for 36-225."
     },
     {

--- a/src/data/advancedCredit/cambridge-credit.json
+++ b/src/data/advancedCredit/cambridge-credit.json
@@ -1,0 +1,282 @@
+[
+    {
+        "exams": [{ "name": "Accounting (A Level)", "score": "B" }],
+        "courses": ["70-122"],
+        "subject": "Humanities",
+        "school": [],
+        "info": ""
+    },
+    {
+        "exams": [{ "name": "Accounting (A Level)", "score": "A" }],
+        "courses": ["70-122"],
+        "subject": "Humanities",
+        "school": [],
+        "info": ""
+    },
+    {
+        "exams": [{ "name": "Arabic (A Level)", "score": "B" }],
+        "courses": ["82-039"],
+        "subject": "Humanities",
+        "school": [],
+        "info": "(students who wish to continue their study of Arabic must take the placement exam and contact the Department of Languages, Cultures & Applied Linguistics for placement)"
+    },
+    {
+        "exams": [{ "name": "Arabic (A Level)", "score": "A" }],
+        "courses": ["82-040"],
+        "subject": "Humanities",
+        "school": [],
+        "info": "(students who wish to continue their study of Arabic must take the placement exam and contact the Department of Languages, Cultures & Applied Linguistics for placement)"
+    },
+    {
+        "exams": [{ "name": "Biology / Advanced Bio (9Bi07) (A Level)", "score": "B" }],
+        "courses": ["03-011"],
+        "subject": "STEM",
+        "school": [],
+        "info": ""
+    },
+    {
+        "exams": [{ "name": "Biology / Advanced Bio (9Bi07) (A Level)", "score": "A" }],
+        "courses": ["03-110"],
+        "subject": "STEM",
+        "school": [],
+        "info": "(students can elect to take an attainment exam. Students who pass this exam by September 30 will receive credit for 03-121 instead of 03-110)"
+    },
+    {
+        "exams": [{ "name": "Chemistry / Advanced Chemistry (9Ch07) (A Level)", "score": "A" }],
+        "courses": ["09-105"],
+        "subject": "STEM",
+        "school": [],
+        "info": ""
+    },
+    {
+        "exams": [{ "name": "Chinese (A Level)", "score": "B" }],
+        "courses": ["82-041"],
+        "subject": "Humanities",
+        "school": [],
+        "info": "(students who wish to continue their study of Chinese must take the placement exam and contact the Department of Languages, Cultures & Applied Linguistics for placement)"
+    },
+    {
+        "exams": [{ "name": "Chinese (A Level)", "score": "A" }],
+        "courses": ["82-042"],
+        "subject": "Humanities",
+        "school": [],
+        "info": "(students who wish to continue their study of Chinese must take the placement exam and contact the Department of Languages, Cultures & Applied Linguistics for placement)"
+    },
+    {
+        "exams": [{ "name": "Classical Studies (A Level)", "score": "B" }],
+        "courses": ["66-013"],
+        "subject": "Humanities",
+        "school": [],
+        "info": ""
+    },
+    {
+        "exams": [{ "name": "Classical Studies (A Level)", "score": "A" }],
+        "courses": ["66-013"],
+        "subject": "Humanities",
+        "school": [],
+        "info": ""
+    },
+    {
+        "exams": [{ "name": "Computer Science (A Level)", "score": "A" }],
+        "courses": ["15-112"],
+        "subject": "STEM",
+        "school": [],
+        "info": "(subsumes 15-110)"
+    },
+    {
+        "exams": [{ "name": "Divinity (A Level)", "score": "B" }],
+        "courses": ["66-014"],
+        "subject": "Humanities",
+        "school": [],
+        "info": ""
+    },
+    {
+        "exams": [{ "name": "Divinity (A Level)", "score": "A" }],
+        "courses": ["66-014"],
+        "subject": "Humanities",
+        "school": [],
+        "info": ""
+    },
+    {
+        "exams": [{ "name": "Economics (A Level)", "score": "A" }],
+        "courses": ["73-011"],
+        "subject": "Humanities",
+        "school": [],
+        "info": "(students should take 73-104)"
+    },
+    {
+        "exams": [{ "name": "English: Language (A Level)", "score": "A" }],
+        "courses": ["76-015"],
+        "subject": "Humanities",
+        "school": [],
+        "info": "(must take 76-101 or two of the following half-semester mini courses at CMU: 76-106, 76-107, 76-108). Multilingual students with a grade of A can enroll in 76-101 or two of three mini courses (76-106, 76-107, 76-108) without taking the English placement exam for non-native English speakers."
+    },
+    {
+        "exams": [{ "name": "English: Literature (A Level)", "score": "A" }],
+        "courses": ["76-016"],
+        "subject": "Humanities",
+        "school": [],
+        "info": "(must take 76-101 or two of the following half-semester mini courses at CMU: 76-106, 76-107, 76-108). Multilingual students with a grade of A can enroll in either 76-101 or two of three mini courses (76-106, 76-107, 76-108) without taking the English placement exam for non-native English speakers."
+    },
+    {
+        "exams": [{ "name": "French (A Level)", "score": "B" }],
+        "courses": ["82-043"],
+        "subject": "Humanities",
+        "school": [],
+        "info": "(students who wish to continue their study of French must take the placement exam and contact the Department of Languages, Cultures & Applied Linguistics for placement)"
+    },
+    {
+        "exams": [{ "name": "French (A Level)", "score": "A" }],
+        "courses": ["82-044"],
+        "subject": "Humanities",
+        "school": [],
+        "info": "(students who wish to continue their study of French must take the placement exam and contact the Department of Languages, Cultures & Applied Linguistics for placement)"
+    },
+    {
+        "exams": [{ "name": "Geography (A Level)", "score": "B" }],
+        "courses": ["66-015"],
+        "subject": "Humanities",
+        "school": [],
+        "info": ""
+    },
+    {
+        "exams": [{ "name": "Geography (A Level)", "score": "A" }],
+        "courses": ["66-015"],
+        "subject": "Humanities",
+        "school": [],
+        "info": ""
+    },
+    {
+        "exams": [{ "name": "German (A Level)", "score": "B" }],
+        "courses": ["82-045"],
+        "subject": "Humanities",
+        "school": [],
+        "info": "(students who wish to continue their study of German must take the placement exam and contact the Department of Languages, Cultures & Applied Linguistics for placement)"
+    },
+    {
+        "exams": [{ "name": "German (A Level)", "score": "A" }],
+        "courses": ["82-046"],
+        "subject": "Humanities",
+        "school": [],
+        "info": "(students who wish to continue their study of German must take the placement exam and contact the Department of Languages, Cultures & Applied Linguistics for placement)"
+    },
+    {
+        "exams": [{ "name": "Hinduism (A Level)", "score": "B" }],
+        "courses": ["66-016"],
+        "subject": "Humanities",
+        "school": [],
+        "info": ""
+    },
+    {
+        "exams": [{ "name": "Hinduism (A Level)", "score": "A" }],
+        "courses": ["66-016"],
+        "subject": "Humanities",
+        "school": [],
+        "info": ""
+    },
+    {
+        "exams": [{ "name": "Islamic Studies (A Level)", "score": "B" }],
+        "courses": ["66-017"],
+        "subject": "Humanities",
+        "school": [],
+        "info": ""
+    },
+    {
+        "exams": [{ "name": "Islamic Studies (A Level)", "score": "A" }],
+        "courses": ["66-017"],
+        "subject": "Humanities",
+        "school": [],
+        "info": ""
+    },
+    {
+        "exams": [{ "name": "Japanese (A Level)", "score": "B" }],
+        "courses": ["82-047"],
+        "subject": "Humanities",
+        "school": [],
+        "info": "(students who wish to continue their study of Japanese must take the placement exam and contact the Department of Languages, Cultures & Applied Linguistics for placement)"
+    },
+    {
+        "exams": [{ "name": "Japanese (A Level)", "score": "A" }],
+        "courses": ["82-048"],
+        "subject": "Humanities",
+        "school": [],
+        "info": "(students who wish to continue their study of Japanese must take the placement exam and contact the Department of Languages, Cultures & Applied Linguistics for placement)"
+    },
+    {
+        "exams": [{ "name": "Law (A Level)", "score": "B" }],
+        "courses": ["66-018"],
+        "subject": "Humanities",
+        "school": [],
+        "info": ""
+    },
+    {
+        "exams": [{ "name": "Law (A Level)", "score": "A" }],
+        "courses": ["66-018"],
+        "subject": "Humanities",
+        "school": [],
+        "info": ""
+    },
+    {
+        "exams": [{ "name": "Mathematics (A Level)", "score": "B" }],
+        "courses": ["21-120"],
+        "subject": "STEM",
+        "school": [],
+        "info": ""
+    },
+    {
+        "exams": [{ "name": "Mathematics / C or Advanced Math (9371) or (9758) or (9709) (A Level)", "score": "A" }],
+        "courses": ["21-120", "21-122"],
+        "subject": "STEM",
+        "school": [],
+        "info": ""
+    },
+    {
+        "exams": [{ "name": "Further Mathematics C (A Level)", "score": "A" }],
+        "courses": ["36-225"],
+        "subject": "STEM",
+        "school": [],
+        "info": "Prerequisite waiver only: if a student takes and passes 36-226, 9 units of credit is awarded for 36-225."
+    },
+    {
+        "exams": [{ "name": "Physics / Advanced Physics (9Ph07) (A Level)", "score": "B" }],
+        "courses": ["33-141", "33-142"],
+        "subject": "STEM",
+        "school": [],
+        "info": ""
+    },
+    {
+        "exams": [{ "name": "Physics / Advanced Physics (9Ph07) (A Level)", "score": "A" }],
+        "courses": ["33-141", "33-142"],
+        "subject": "STEM",
+        "school": [],
+        "info": ""
+    },
+    {
+        "exams": [{ "name": "Sociology (A Level)", "score": "B" }],
+        "courses": ["88-011"],
+        "subject": "Humanities",
+        "school": [],
+        "info": ""
+    },
+    {
+        "exams": [{ "name": "Sociology (A Level)", "score": "A" }],
+        "courses": ["88-011"],
+        "subject": "Humanities",
+        "school": [],
+        "info": ""
+    },
+    {
+        "exams": [{ "name": "Spanish (A Level)", "score": "B" }],
+        "courses": ["82-049"],
+        "subject": "Humanities",
+        "school": [],
+        "info": "(students who wish to continue their study of Spanish must take the placement exam and contact the Department of Languages, Cultures & Applied Linguistics for placement)"
+    },
+    {
+        "exams": [{ "name": "Spanish (A Level)", "score": "A" }],
+        "courses": ["82-050"],
+        "subject": "Humanities",
+        "school": [],
+        "info": "(students who wish to continue their study of Spanish must take the placement exam and contact the Department of Languages, Cultures & Applied Linguistics for placement)"
+    }
+]

--- a/src/data/advancedCredit/cambridge-credit.json
+++ b/src/data/advancedCredit/cambridge-credit.json
@@ -28,21 +28,21 @@
         "info": "(students who wish to continue their study of Arabic must take the placement exam and contact the Department of Languages, Cultures & Applied Linguistics for placement)"
     },
     {
-        "exams": [{ "name": "Biology / Advanced Bio (9Bi07) (A Level)", "score": "B" }],
+        "exams": [{ "name": "Biology (A Level)", "score": "B" }],
         "courses": ["03-011"],
         "subject": "STEM",
         "school": [],
         "info": ""
     },
     {
-        "exams": [{ "name": "Biology / Advanced Bio (9Bi07) (A Level)", "score": "A" }],
+        "exams": [{ "name": "Biology (A Level)", "score": "A" }],
         "courses": ["03-110"],
         "subject": "STEM",
         "school": [],
         "info": "(students can elect to take an attainment exam. Students who pass this exam by September 30 will receive credit for 03-121 instead of 03-110)"
     },
     {
-        "exams": [{ "name": "Chemistry / Advanced Chemistry (9Ch07) (A Level)", "score": "A" }],
+        "exams": [{ "name": "Chemistry (A Level)", "score": "A" }],
         "courses": ["09-105"],
         "subject": "STEM",
         "school": [],
@@ -224,28 +224,28 @@
         "info": ""
     },
     {
-        "exams": [{ "name": "Mathematics / C or Advanced Math (9371) or (9758) or (9709) (A Level)", "score": "A" }],
+        "exams": [{ "name": "Mathematics (A Level)", "score": "A" }],
         "courses": ["21-120", "21-122"],
         "subject": "STEM",
         "school": [],
         "info": ""
     },
     {
-        "exams": [{ "name": "Further Mathematics C (A Level)", "score": "A" }],
+        "exams": [{ "name": "Further Mathematics (A Level)", "score": "A" }],
         "courses": ["36-225"],
         "subject": "STEM",
         "school": [],
         "info": "Prerequisite waiver only: if a student takes and passes 36-226, 9 units of credit is awarded for 36-225."
     },
     {
-        "exams": [{ "name": "Physics / Advanced Physics (9Ph07) (A Level)", "score": "B" }],
+        "exams": [{ "name": "Physics (A Level)", "score": "B" }],
         "courses": ["33-141", "33-142"],
         "subject": "STEM",
         "school": [],
         "info": ""
     },
     {
-        "exams": [{ "name": "Physics / Advanced Physics (9Ph07) (A Level)", "score": "A" }],
+        "exams": [{ "name": "Physics (A Level)", "score": "A" }],
         "courses": ["33-141", "33-142"],
         "subject": "STEM",
         "school": [],

--- a/src/data/nonOfferedCourses.json
+++ b/src/data/nonOfferedCourses.json
@@ -136,5 +136,29 @@
     { "id": "79-016", "name": "IB Anthropology", "units": "9" },
     
     { "id": "82-037", "name": "IB 6 Spanish", "units": "9" },
-    { "id": "82-038", "name": "IB 7 Spanish", "units": "9" }
+    { "id": "82-038", "name": "IB 7 Spanish", "units": "9" },
+
+    { "id": "82-039", "name": "CMBR B Arabic", "units": "12" },
+    { "id": "82-040", "name": "CMBR A Arabic", "units": "12" },
+    { "id": "82-041", "name": "CMBR B Chinese", "units": "12" },
+    { "id": "82-042", "name": "CMBR A Chinese", "units": "12" },
+    { "id": "82-043", "name": "CMBR B French", "units": "9" },
+    { "id": "82-044", "name": "CMBR A French", "units": "9" },
+    { "id": "82-045", "name": "CMBR B German", "units": "9" },
+    { "id": "82-046", "name": "CMBR A German", "units": "9" },
+    { "id": "82-047", "name": "CMBR B Japanese", "units": "12" },
+    { "id": "82-048", "name": "CMBR A Japanese", "units": "12" },
+    { "id": "82-049", "name": "CMBR B Spanish", "units": "9" },
+    { "id": "82-050", "name": "CMBR A Spanish", "units": "9" },
+
+    { "id": "66-013", "name": "CMBR Classical Studies", "units": "9" },
+    { "id": "66-014", "name": "CMBR Divinity", "units": "9" },
+    { "id": "66-015", "name": "CMBR Geography", "units": "9" },
+    { "id": "66-016", "name": "CMBR Hinduism", "units": "9" },
+    { "id": "66-017", "name": "CMBR Islamic Studies", "units": "9" },
+    { "id": "66-018", "name": "CMBR Law", "units": "9" },
+    { "id": "76-015", "name": "CMBR English: Language", "units": "9" },
+    { "id": "76-016", "name": "CMBR English: Literature", "units": "9" },
+    { "id": "88-011", "name": "CMBR Sociology", "units": "9" }
 ]
+

--- a/src/utils/advancedCreditCourseUtils.ts
+++ b/src/utils/advancedCreditCourseUtils.ts
@@ -127,6 +127,15 @@ export async function loadCreditData(
                 return course;
             });
 
+            const scores: { score: number | string; courses: Course[] }[] = [
+                { score: exam.score, courses: scoreCourses },
+            ];
+
+            // A* is the highest Cambridge grade and satisfies any A requirement
+            if (creditType === "Cambridge" && exam.score === "A") {
+                scores.push({ score: "A*", courses: scoreCourses });
+            }
+
             exams.push({
                 name: exam.name,
                 subject: entry.subject as
@@ -136,12 +145,7 @@ export async function loadCreditData(
                     | "N/A",
                 school: entry.school as School[],
                 info: entry.info?.trim() || "",
-                scores: [
-                    {
-                        score: exam.score,
-                        courses: scoreCourses,
-                    },
-                ],
+                scores,
             });
         }
     }

--- a/src/utils/advancedCreditCourseUtils.ts
+++ b/src/utils/advancedCreditCourseUtils.ts
@@ -7,6 +7,9 @@ import apCreditData from "../data/advancedCredit/ap-credit.json" with {
 import ibCreditData from "../data/advancedCredit/ib-credit.json" with {
     type: "json",
 };
+import cambridgeCreditData from "../data/advancedCredit/cambridge-credit.json" with {
+    type: "json",
+};
 
 import nonOfferedCourses from "../data/nonOfferedCourses.json" with {
     type: "json",
@@ -14,7 +17,7 @@ import nonOfferedCourses from "../data/nonOfferedCourses.json" with {
 
 export type School = "DC" | "CIT" | "SCS" | "TEP" | "MCS" | "CFA";
 
-export type AdvancedCreditType = "AP" | "IB";
+export type AdvancedCreditType = "AP" | "IB" | "Cambridge";
 
 export type Exam = {
     name: string;
@@ -22,7 +25,7 @@ export type Exam = {
     school: School[];
     info: string;
     scores: {
-        score: number;
+        score: number | string;
         courses: Course[];
     }[];
 };
@@ -33,7 +36,10 @@ export type AdvancedCreditCourse = {
     units: string;
 };
 
-export const SCORE_RANGES = {
+export const SCORE_RANGES: Record<
+    AdvancedCreditType,
+    { label: string; min?: number; max?: number; options?: string[] }
+> = {
     AP: {
         label: "Score (1-5)",
         min: 1,
@@ -44,6 +50,10 @@ export const SCORE_RANGES = {
         min: 1,
         max: 7,
     },
+    Cambridge: {
+        label: "Grade (A*-E)",
+        options: ["A*", "A", "B", "C", "D", "E"],
+    },
 };
 
 export async function loadCreditData(
@@ -51,7 +61,12 @@ export async function loadCreditData(
 ): Promise<Exam[]> {
     const exams: Exam[] = [];
 
-    const creditData = creditType === "AP" ? apCreditData : ibCreditData;
+    const creditData =
+        creditType === "AP"
+            ? apCreditData
+            : creditType === "IB"
+              ? ibCreditData
+              : cambridgeCreditData;
 
     const courses = CoursesData as Record<string, Course>;
     const coursesIndex: Record<string, Course> = Object.fromEntries(
@@ -92,7 +107,8 @@ export async function loadCreditData(
                     };
                 } else if (
                     course.name.startsWith("AP") ||
-                    course.name.startsWith("IB")
+                    course.name.startsWith("IB") ||
+                    course.name.startsWith("CMBR")
                 ) {
                     return {
                         id,

--- a/src/utils/advancedCreditCourseUtils.ts
+++ b/src/utils/advancedCreditCourseUtils.ts
@@ -24,6 +24,7 @@ export type Exam = {
     subject: "STEM" | "Arts" | "Humanities" | "N/A";
     school: School[];
     info: string;
+    overrideUnits?: number;
     scores: {
         score: number | string;
         courses: Course[];
@@ -145,6 +146,7 @@ export async function loadCreditData(
                     | "N/A",
                 school: entry.school as School[],
                 info: entry.info?.trim() || "",
+                overrideUnits: (entry as any).overrideUnits,
                 scores,
             });
         }

--- a/src/utils/creditCalculatorForm.ts
+++ b/src/utils/creditCalculatorForm.ts
@@ -275,7 +275,9 @@ export class SetupForm {
         if (!field) return;
 
         const raw = interaction.values[0];
-        const parsedScore = SCORE_RANGES[this.schema.type].options ? raw : Number(raw);
+        const parsedScore = SCORE_RANGES[this.schema.type].options
+            ? raw
+            : Number(raw);
 
         if (!this.state.collectedData[field.key]) {
             this.state.collectedData[field.key] = [];

--- a/src/utils/creditCalculatorForm.ts
+++ b/src/utils/creditCalculatorForm.ts
@@ -274,7 +274,8 @@ export class SetupForm {
         const field = this.schema.fields.find((f) => f.key === fieldKey);
         if (!field) return;
 
-        const score = Number(interaction.values[0]);
+        const raw = interaction.values[0];
+        const parsedScore = SCORE_RANGES[this.schema.type].options ? raw : Number(raw);
 
         if (!this.state.collectedData[field.key]) {
             this.state.collectedData[field.key] = [];
@@ -284,9 +285,9 @@ export class SetupForm {
 
         const existing = arr.find((e: any) => e.examName === examName);
         if (existing) {
-            existing.score = score;
+            existing.score = parsedScore;
         } else {
-            arr.push({ examName, score });
+            arr.push({ examName, score: parsedScore });
         }
 
         await interaction.update({
@@ -323,21 +324,17 @@ export class SetupForm {
             .setCustomId(
                 `setup;${this.schema.name};score;${field.key};${examName};${this.rendNonce}`,
             )
-            .setPlaceholder(`Select score for ${examName}`)
-            .addOptions(
-                Array.from(
-                    {
-                        length:
-                            SCORE_RANGES[this.schema.type].max -
-                            SCORE_RANGES[this.schema.type].min +
-                            1,
-                    },
-                    (_, i) => i + SCORE_RANGES[this.schema.type].min,
-                ).map((n) => ({
-                    label: n.toString(),
-                    value: n.toString(),
-                })),
-            );
+            .setPlaceholder(`Select score for ${examName}`);
+        const range = SCORE_RANGES[this.schema.type];
+        // letter grades (Cambridge) vs numeric range (AP/IB)
+        const scoreOptions = range.options
+            ? range.options.map((o) => ({ label: o, value: o }))
+            : Array.from(
+                  { length: range.max! - range.min! + 1 },
+                  (_, i) => i + range.min!,
+              ).map((n) => ({ label: n.toString(), value: n.toString() }));
+
+        scoreSelect.addOptions(scoreOptions);
 
         return new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
             scoreSelect,


### PR DESCRIPTION
Adds support for Cambridge A Level credits. 
- includes necessary changes for letter-based grading 
- adds overrideUnits for prerequisite-waiver-only entries (e.g. Further Mathematics)
Closes #176  