### PR TITLE
refactor: use discord's native permission checks for /steal over manual permission checks

### DIFF
--- a/src/commands/steal.ts
+++ b/src/commands/steal.ts
@@ -4,7 +4,6 @@ import {
     EmbedBuilder,
     GuildMember,
     PermissionFlagsBits,
-    PermissionsBitField,
     parseEmoji,
     type PartialEmoji,
     RESTJSONErrorCodes,
@@ -146,15 +145,6 @@ const command: SlashCommand = {
         if (!guild || !(member instanceof GuildMember)) {
             return interaction.reply({
                 content: "This command must be used in a server",
-                ephemeral: true,
-            });
-        }
-
-        const hasPerms = member.permissions.has(PermissionsBitField.Flags.ManageGuildExpressions);
-
-        if (!hasPerms) {
-            return interaction.reply({
-                content: "You need the Manage Guild Expressions permission to use this command.",
                 ephemeral: true,
             });
         }

--- a/src/commands/steal.ts
+++ b/src/commands/steal.ts
@@ -2,13 +2,14 @@ import {
     Client,
     DiscordAPIError,
     EmbedBuilder,
+    GuildMember,
+    PermissionFlagsBits,
+    PermissionsBitField,
     parseEmoji,
     type PartialEmoji,
     RESTJSONErrorCodes,
     SlashCommandBuilder,
     StickerFormatType,
-    PermissionsBitField,
-    GuildMember,
 } from "discord.js";
 import { Buffer } from "node:buffer";
 import type { SlashCommand } from "../types.d.ts";
@@ -122,7 +123,10 @@ function parseEmojiInput(input: string): {
 const command: SlashCommand = {
     data: new SlashCommandBuilder()
         .setName("steal")
-        .setDescription("Steals emotes, stickers, or soundboards from another server")
+        .setDescription(
+            "Steals emotes, stickers, or soundboards from another server",
+        )
+        .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuildExpressions)
         .addStringOption((option) =>
             option
                 .setName("id")


### PR DESCRIPTION
Switches to `setDefaultMemberPermissions`, supersedes #182 